### PR TITLE
Adiciona a página de erro 404 

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,13 +1,48 @@
-import Link from "next/link";
+import { Button, Stack, Typography } from "@mui/material";
 
-function NotFound() {
+function NotFoundPage() {
   return (
-    <div>
-      <h2>Not Found</h2>
-      <p>Could not find requested resource</p>
-      <Link href="/">Return Home</Link>
-    </div>
+    <Stack
+      width="100%"
+      height="100dvh"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Stack alignItems="center" padding={2}>
+        <Typography variant="h1" color="text.primary">
+          404
+        </Typography>
+
+        <Typography
+          variant="body1"
+          color="text.primary"
+          textAlign="center"
+          fontWeight={600}
+        >
+          Página não encontrada
+        </Typography>
+
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          maxWidth={300}
+          textAlign="center"
+          mt={2}
+        >
+          Ela pode ter sido removida ou o endereço está incorreto.
+        </Typography>
+
+        <Button
+          variant="text"
+          color="primary"
+          href="/"
+          sx={{ mt: 8, fontWeight: 600 }}
+        >
+          Voltar para a home
+        </Button>
+      </Stack>
+    </Stack>
   );
 }
 
-export default NotFound;
+export default NotFoundPage;


### PR DESCRIPTION
# Descrição

Este PR refatora a página de erro 404 da aplicação, que anteriormente exibia um layout simples e sem estilo, com textos em inglês e elementos HTML básicos (`div`, `h2`, `p`). A solução substitui essa implementação por componentes MUI (`Stack`, `Typography`, `Button`), apresentando mensagens em português — "Página não encontrada" e "Ela pode ter sido removida ou o endereço está incorreto." — além de um botão para retorno à home. O componente também foi renomeado de `NotFound` para `NotFoundPage`.

## Capturas/Gravação de tela

|Imagem|
|-|
|<img width="1919" height="846" alt="image" src="https://github.com/user-attachments/assets/47fde2e4-12b5-4ccf-a82d-f71975a65018" />|

## Como isso foi testado?

- Testes Manuais
