### PR TITLE
Adiciona configuração de tema MUI com breakpoints, tipografia e espaçamento customizados

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.8",
     "@mui/material": "^7.3.8",
+    "@mui/material-nextjs": "^7.3.9",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,7 +1,16 @@
+"use client";
+
 import type { ReactNode } from "react";
+import { ThemeProvider } from "@mui/material/styles";
+import { AppRouterCacheProvider } from "@mui/material-nextjs/v16-appRouter";
+import theme from "@/shared/lib/mui/theme/theme.config";
 
 function Providers({ children }: { children: ReactNode }) {
-  return children;
+  return (
+    <AppRouterCacheProvider>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </AppRouterCacheProvider>
+  );
 }
 
 export default Providers;

--- a/src/shared/lib/mui/theme/breakpoints/breakpoints.config.ts
+++ b/src/shared/lib/mui/theme/breakpoints/breakpoints.config.ts
@@ -1,0 +1,11 @@
+const breakpoints = {
+  values: {
+    xs: 0,
+    sm: 600,
+    md: 900,
+    lg: 1200,
+    xl: 1400,
+  },
+};
+
+export default breakpoints;

--- a/src/shared/lib/mui/theme/theme.config.ts
+++ b/src/shared/lib/mui/theme/theme.config.ts
@@ -1,0 +1,12 @@
+import { createTheme } from "@mui/material/styles";
+
+import breakpoints from "./breakpoints/breakpoints.config";
+import typography from "./typography/typography.config";
+
+const theme = createTheme({
+  spacing: 4,
+  breakpoints,
+  typography,
+});
+
+export default theme;

--- a/src/shared/lib/mui/theme/typography/typography.config.ts
+++ b/src/shared/lib/mui/theme/typography/typography.config.ts
@@ -1,0 +1,7 @@
+const typography = {
+  fontFamily: '"Open Sans", Roboto, "Helvetica Neue", Arial, sans-serif',
+  fontSize: 16,
+  htmlFontSize: 16,
+};
+
+export default typography;

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,6 +559,13 @@
   dependencies:
     "@babel/runtime" "^7.28.6"
 
+"@mui/material-nextjs@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@mui/material-nextjs/-/material-nextjs-7.3.9.tgz#0e3efd5342ab8788481eb4f3f4cd8a4746e2d958"
+  integrity sha512-ahCIvEhRnX4/xznSr/bn6cLzPppcLohfVc65k7AFAIDazWMGo9yVCCSdL7fqvwluDTZiIyqnweb30xOZMTeyRg==
+  dependencies:
+    "@babel/runtime" "^7.28.6"
+
 "@mui/material@^7.3.8":
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-7.3.8.tgz#230230b5aa6a791558874ecffe9c50ffa0be6817"


### PR DESCRIPTION
# Descrição

Este PR implementa a configuração do tema MUI na aplicação, que anteriormente não possuía tema customizado e utilizava apenas os valores padrão da biblioteca.

A solução criou uma estrutura modular de tema com arquivos dedicados para breakpoints (`breakpoints.config.ts`), tipografia (`typography.config.ts`) e o tema principal (`theme.config.ts`), utilizando `createTheme` com espaçamento base de 4px. O componente `Providers` foi atualizado para envolver a aplicação com `AppRouterCacheProvider` (necessário para compatibilidade com o App Router do Next.js) e `ThemeProvider`. 



## Como isso foi testado?

- Testes Manuais

