### PR TITLE
Corrige warning de hidratação na tag body causado por extensões externas do navegador

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${openSans.className} ${cookie.variable}`}>
+      <body className={`${openSans.className} ${cookie.variable}`} suppressHydrationWarning>
         <Providers>{children}</Providers>
       </body>
     </html>


### PR DESCRIPTION
# Descrição

Este PR corrige um warning de hidratação gerado pelo Next.js na tag `<body>` ao rodar o projeto localmente. O warning ocorria porque extensões externas do navegador modificam atributos do DOM após a renderização no servidor, causando mismatch entre o HTML gerado pelo servidor e o do cliente. A solução foi adicionar a prop `suppressHydrationWarning` na tag `<body>` em `src/app/layout.tsx`, instruindo o React a ignorar diferenças de hidratação nesse elemento.

## Como isso foi testado?

- Testes Manuais

