### PR TITLE
Adiciona componente de rodapé ao portal

### DIFF
--- a/src/app/(portal)/_components/footer/Footer.component.tsx
+++ b/src/app/(portal)/_components/footer/Footer.component.tsx
@@ -1,0 +1,63 @@
+import { IconButton, Link, Stack, Typography } from "@mui/material";
+
+import LinkedInIcon from "@mui/icons-material/LinkedIn";
+import EmailIcon from "@mui/icons-material/Email";
+import GitHubIcon from "@mui/icons-material/GitHub";
+
+import {
+  EMAIL_URL,
+  GITHUB_PROFILE_URL,
+  LINKEDIN_PROFILE_URL,
+} from "@/shared/constants/links.constants";
+
+import { items } from "./Footer.config";
+
+function Footer() {
+  return (
+    <Stack
+      component="footer"
+      alignItems="center"
+      paddingY={4}
+      bgcolor="background.default"
+      borderTop={1}
+      borderColor="divider"
+    >
+      <Stack spacing={4} py={{ xs: 12, sm: 24 }} px={4}>
+        <Stack direction="row" flexWrap="wrap" gap={4} justifyContent="center">
+          {items.map((item) => (
+            <Link
+              variant="body2"
+              key={item.label}
+              href={item.href}
+              rel="noopener noreferrer"
+              color="textSecondary"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </Stack>
+
+        <Typography variant="caption" color="text.secondary" textAlign="center">
+          Meu Portfólio &copy; {new Date().getFullYear()} - 2022. Todos os
+          direitos reservados.
+        </Typography>
+
+        <Stack direction="row" spacing={2} justifyContent="center">
+          <IconButton href={LINKEDIN_PROFILE_URL} color="info">
+            <LinkedInIcon fontSize="small" />
+          </IconButton>
+
+          <IconButton href={GITHUB_PROFILE_URL} color="info">
+            <GitHubIcon fontSize="small" />
+          </IconButton>
+
+          <IconButton href={EMAIL_URL} color="info">
+            <EmailIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default Footer;

--- a/src/app/(portal)/_components/footer/Footer.config.tsx
+++ b/src/app/(portal)/_components/footer/Footer.config.tsx
@@ -1,0 +1,20 @@
+import { LINKEDIN_PROFILE_URL } from "@/shared/constants/links.constants";
+
+export const items = [
+  {
+    label: "Contato",
+    href: LINKEDIN_PROFILE_URL,
+  },
+  {
+    label: "Sobre",
+    href: "/#about",
+  },
+  {
+    label: "Projetos",
+    href: "/#projects",
+  },
+  {
+    label: "Tela Inicial",
+    href: "/",
+  },
+];

--- a/src/app/(portal)/layout.tsx
+++ b/src/app/(portal)/layout.tsx
@@ -1,0 +1,12 @@
+import Footer from "./_components/footer/Footer.component";
+
+function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <Footer />
+    </>
+  );
+}
+
+export default Layout;

--- a/src/shared/constants/links.constants.ts
+++ b/src/shared/constants/links.constants.ts
@@ -1,0 +1,6 @@
+export const LINKEDIN_PROFILE_URL =
+  "https://www.linkedin.com/in/davhy-andrade-dev/";
+
+export const EMAIL_URL = "mailto:contato@davhyandrade.com.br";
+
+export const GITHUB_PROFILE_URL = "https://github.com/davhyandrade";


### PR DESCRIPTION
# Descrição

Este PR adiciona um componente de rodapé (`Footer`) ao portal. O portal não possuía rodapé, o que deixava a página sem links de navegação secundária, informações de copyright e atalhos para redes sociais.

A solução introduz o componente `Footer` com três áreas: links de navegação interna (Contato, Sobre, Projetos, Tela Inicial), aviso de copyright dinâmico com o ano atual, e botões de ícone para LinkedIn, GitHub e e-mail. As URLs externas foram centralizadas no arquivo `links.constants.ts`, e os itens do menu foram isolados no arquivo de configuração `Footer.config.tsx`. O componente foi integrado ao layout do portal via `layout.tsx`, garantindo sua exibição em todas as páginas da rota `(portal)`.

## Capturas/Gravação de tela
|Imagem|
|-|
|<img width="1913" height="337" alt="image" src="https://github.com/user-attachments/assets/44f21ba1-4462-4cbf-911b-426b76a50be7" />|

## Como isso foi testado?

- Testes Manuais

