### PR TITLE
Adiciona estilos customizados ao componente Typography do MUI

### DIFF
--- a/src/shared/lib/mui/theme/components/typography/typography.config.ts
+++ b/src/shared/lib/mui/theme/components/typography/typography.config.ts
@@ -1,0 +1,24 @@
+import type { Components, Theme } from "@mui/material/styles";
+
+export const MuiTypography: Components<Theme>["MuiTypography"] = {
+  variants: [
+    {
+      props: { variant: "body1" },
+      style: {
+        fontSize: 16,
+      },
+    },
+    {
+      props: { variant: "body2" },
+      style: {
+        fontSize: 14,
+      },
+    },
+    {
+      props: { variant: "caption" },
+      style: {
+        fontSize: 13,
+      },
+    },
+  ],
+};

--- a/src/shared/lib/mui/theme/theme.config.ts
+++ b/src/shared/lib/mui/theme/theme.config.ts
@@ -4,6 +4,7 @@ import breakpoints from "./breakpoints/breakpoints.config";
 import typography from "./typography/typography.config";
 
 import { MuiLink } from "./components/link/link.config";
+import { MuiTypography } from "./components/typography/typography.config";
 
 const theme = createTheme({
   spacing: 4,
@@ -11,6 +12,7 @@ const theme = createTheme({
   typography,
   components: {
     MuiLink,
+    MuiTypography,
   },
 });
 


### PR DESCRIPTION
# Descrição

Este PR adiciona estilos customizados ao componente `Typography` do MUI no tema global da aplicação.

Não havia configuração de estilos dedicada para o componente `MuiTypography` no tema, o que deixava os tamanhos de fonte das variantes de texto sem padronização explícita. A solução foi criar um arquivo de configuração exclusivo para o componente `MuiTypography`, definindo tamanhos de fonte específicos para as variantes `body1` (16px), `body2` (14px) e `caption` (13px). Esse arquivo é importado e registrado no tema global através da propriedade `components` no `theme.config.ts`.

## Como isso foi testado?

- Testes Manuais

## Informações adicionais

- [MUI - Typography](https://mui.com/material-ui/react-typography/)
