### PR TITLE
Adiciona estilos customizados ao componente Link do MUI

### DIFF
--- a/src/shared/lib/mui/theme/components/link/link.config.ts
+++ b/src/shared/lib/mui/theme/components/link/link.config.ts
@@ -1,0 +1,28 @@
+import type { Components, Theme } from "@mui/material/styles";
+
+export const MuiLink: Components<Theme>["MuiLink"] = {
+  defaultProps: {
+    underline: "none",
+  },
+  styleOverrides: {
+    root: {
+      transition: "color 0.3s",
+    },
+  },
+  variants: [
+    {
+      props: { color: "textSecondary" },
+      style: ({ theme }) => ({
+        color: theme.palette.text.secondary,
+
+        "&:hover, &:focus": {
+          color: theme.palette.text.primary,
+        },
+
+        "&:active": {
+          color: theme.palette.text.disabled,
+        },
+      }),
+    },
+  ],
+};

--- a/src/shared/lib/mui/theme/theme.config.ts
+++ b/src/shared/lib/mui/theme/theme.config.ts
@@ -3,10 +3,15 @@ import { createTheme } from "@mui/material/styles";
 import breakpoints from "./breakpoints/breakpoints.config";
 import typography from "./typography/typography.config";
 
+import { MuiLink } from "./components/link/link.config";
+
 const theme = createTheme({
   spacing: 4,
   breakpoints,
   typography,
+  components: {
+    MuiLink,
+  },
 });
 
 export default theme;


### PR DESCRIPTION
# Descrição

Este PR adiciona uma configuração de estilos customizados para o componente `MuiLink` dentro do tema global do MUI.

Anteriormente, o componente `MuiLink` não possuía nenhuma personalização no tema da aplicação, utilizando apenas os estilos padrão da biblioteca.

A solução consiste na criação do arquivo `link.config.ts`, que define:
- `underline: "none"` como prop padrão, removendo o sublinhado automático dos links;
- Uma transição suave de cor (`color 0.3s`) via `styleOverrides`;
- Uma variante `textSecondary` com estados de `hover`, `focus` e `active` baseados nas cores da paleta do tema (`text.secondary`, `text.primary` e `text.disabled`).

A configuração foi registrada no `theme.config.ts` via a propriedade `components` do `createTheme`.

## Como isso foi testado?

- Testes Manuais

## Informações adicionais

- [MUI - Link](https://mui.com/material-ui/react-link/)