### PR TITLE
Adiciona estilos customizados ao componente Button do MUI

### DIFF
--- a/src/shared/lib/mui/theme/components/button/button.config.ts
+++ b/src/shared/lib/mui/theme/components/button/button.config.ts
@@ -1,0 +1,31 @@
+import type { Components, Theme } from "@mui/material/styles";
+
+export const MuiButton: Components<Theme>["MuiButton"] = {
+  styleOverrides: {
+    root: ({ theme }) => ({
+      fontSize: 16,
+      textTransform: "none",
+      borderRadius: theme.spacing(3),
+      padding: theme.spacing(1, 6),
+      transition: "color 0.3s, border-color 0.3s",
+    }),
+  },
+  variants: [
+    {
+      props: { variant: "text" },
+      style: {
+        border: "2px solid transparent",
+
+        "&:hover": {
+          borderColor: "currentColor",
+        },
+      },
+    },
+    {
+      props: { variant: "outlined" },
+      style: {
+        border: "2px solid",
+      },
+    },
+  ],
+};

--- a/src/shared/lib/mui/theme/theme.config.ts
+++ b/src/shared/lib/mui/theme/theme.config.ts
@@ -5,6 +5,7 @@ import typography from "./typography/typography.config";
 
 import { MuiLink } from "./components/link/link.config";
 import { MuiTypography } from "./components/typography/typography.config";
+import { MuiButton } from "./components/button/button.config";
 
 const theme = createTheme({
   spacing: 4,
@@ -13,6 +14,7 @@ const theme = createTheme({
   components: {
     MuiLink,
     MuiTypography,
+    MuiButton,
   },
 });
 


### PR DESCRIPTION
# Descrição

Este PR adiciona a configuração de estilos customizados para o componente `Button` do MUI, centralizando as overrides visuais no tema global da aplicação.

Anteriormente, o tema MUI não possuía configurações específicas para o componente `Button`, resultando no uso dos estilos padrão da biblioteca. A solução cria um arquivo dedicado (`button.config.ts`) com `styleOverrides` e `variants` customizados — incluindo ajustes de `fontSize`, `borderRadius`, `padding`, remoção do `textTransform` e comportamentos de borda para as variantes `text` (borda ao hover) e `outlined` (borda permanente) — e registra essa configuração na chave `components` do tema global.

## Capturas/Gravação de tela
|Imagem|
|-|
|<img width="412" height="75" alt="image" src="https://github.com/user-attachments/assets/8fc89afa-a065-4161-a75c-f37f6ce989cb" />|


## Como isso foi testado?

- Testes Manuais

## Informações adicionais
- [Mui Button](https://mui.com/material-ui/react-button/)