### PR TITLE
Adiciona paleta de cores personalizada ao tema MUI

### DIFF
--- a/src/shared/lib/mui/theme/palette/palette.config.ts
+++ b/src/shared/lib/mui/theme/palette/palette.config.ts
@@ -1,0 +1,29 @@
+import type { PaletteOptions } from "@mui/material/styles";
+
+const palette: PaletteOptions = {
+  background: {
+    default: "#0a0a0b",
+    paper: "#181b1e",
+  },
+  text: {
+    primary: "#e5e7eb",
+    secondary: "#a5a5a5ff",
+    disabled: "#686868ff",
+  },
+  info: {
+    main: "#e5e7eb",
+    light: "#f0f0f0",
+    dark: "#a5a5a5ff",
+    contrastText: "#0a0a0b",
+  },
+  primary: {
+    main: "#2494d6",
+    light: "#5fb3e3",
+    dark: "#1a6a9a",
+    contrastText: "#0a0a0b",
+  },
+  divider: "#ffffff1a",
+  action: { hoverOpacity: 0.08 },
+};
+
+export default palette;

--- a/src/shared/lib/mui/theme/theme.config.ts
+++ b/src/shared/lib/mui/theme/theme.config.ts
@@ -2,6 +2,7 @@ import { createTheme } from "@mui/material/styles";
 
 import breakpoints from "./breakpoints/breakpoints.config";
 import typography from "./typography/typography.config";
+import palette from "./palette/palette.config";
 
 import { MuiLink } from "./components/link/link.config";
 import { MuiTypography } from "./components/typography/typography.config";
@@ -11,6 +12,7 @@ const theme = createTheme({
   spacing: 4,
   breakpoints,
   typography,
+  palette,
   components: {
     MuiLink,
     MuiTypography,


### PR DESCRIPTION
# Descrição

Este PR adiciona uma paleta de cores personalizada ao tema MUI da aplicação. Anteriormente, o tema não possuía uma paleta configurada, fazendo com que o MUI utilizasse sua paleta padrão (modo claro). A solução consiste na criação do arquivo `palette.config.ts` com definições de cores para background, texto, info, primary, divisor e opacidade de hover, além da integração desta paleta ao `createTheme()` em `theme.config.ts`.

## Como isso foi testado?

- Testes Manuais

