### PR TITLE
Adiciona cor de fundo ao body via variáveis CSS do tema MUI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,7 @@ body {
   font-family: "Open Sans", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--mui-palette-background-default);
 }
 
 * {

--- a/src/shared/lib/mui/theme/theme.config.ts
+++ b/src/shared/lib/mui/theme/theme.config.ts
@@ -9,6 +9,7 @@ import { MuiTypography } from "./components/typography/typography.config";
 import { MuiButton } from "./components/button/button.config";
 
 const theme = createTheme({
+  cssVariables: true,
   spacing: 4,
   breakpoints,
   typography,


### PR DESCRIPTION
# Descrição

Este PR adiciona uma cor de fundo ao elemento `body` da aplicação, utilizando a variável CSS exposta pelo tema do MUI (`--mui-palette-background-default`).

Anteriormente, o `body` não possuía uma cor de fundo definida pelo tema, o que gerava inconsistência visual entre o fundo da página e os componentes estilizados pelo MUI. Para resolver isso, foi habilitada a geração de variáveis CSS no tema (`cssVariables: true` em `theme.config.ts`), permitindo que os tokens do tema sejam acessíveis como CSS custom properties. Com isso, a propriedade `background-color` do `body` passa a consumir o valor do token `background.default` do tema.

## Como isso foi testado?

- Testes Manuais
