### PR TITLE
Refatora estilos padrão do componente Button

### DIFF
--- a/src/shared/lib/mui/theme/components/button/button.config.ts
+++ b/src/shared/lib/mui/theme/components/button/button.config.ts
@@ -4,9 +4,10 @@ export const MuiButton: Components<Theme>["MuiButton"] = {
   styleOverrides: {
     root: ({ theme }) => ({
       fontSize: 16,
+      lineHeight: 1.4,
       textTransform: "none",
-      borderRadius: theme.spacing(3),
-      padding: theme.spacing(1, 6),
+      borderRadius: theme.spacing(4),
+      padding: theme.spacing(1.5, 5),
       transition: "color 0.3s, border-color 0.3s",
     }),
   },


### PR DESCRIPTION
# Descrição

Este PR refatora os estilos padrão do componente `MuiButton` no tema global do MUI. Os valores anteriores de `borderRadius` e `padding` não correspondiam ao padrão visual esperado, e a propriedade `lineHeight` estava ausente, o que podia impactar o alinhamento do texto interno ao botão.

A solução ajusta as seguintes propriedades no `styleOverrides.root`:
- `lineHeight`: adicionado com valor `1.4`
- `borderRadius`: aumentado de `theme.spacing(3)` para `theme.spacing(4)`
- `padding`: ajustado de `theme.spacing(1, 6)` para `theme.spacing(1.5, 5)`


## Como isso foi testado?

- Testes Manuais

