### PR TITLE
Adiciona componente Link customizado integrando MUI com Next.js

### DIFF
--- a/src/shared/lib/mui/components/link/Link.component.tsx
+++ b/src/shared/lib/mui/components/link/Link.component.tsx
@@ -1,0 +1,14 @@
+import NextLink from "next/link";
+
+import { Link as MuiLink } from "@mui/material";
+import type { LinkProps } from "@mui/material";
+
+function Link({ href, children, ...rest }: LinkProps) {
+  return (
+    <MuiLink component={NextLink} href={href} {...rest}>
+      {children}
+    </MuiLink>
+  );
+}
+
+export default Link;

--- a/src/shared/lib/mui/components/link/index.tsx
+++ b/src/shared/lib/mui/components/link/index.tsx
@@ -1,0 +1,3 @@
+import Link from "./Link.component";
+
+export default Link;


### PR DESCRIPTION
# Descrição

Este PR adiciona um componente `Link` customizado que integra o componente `Link` do MUI com o `Link` do Next.js, utilizando a propriedade `component={NextLink}` para combinar os estilos do MUI com o roteamento client-side do Next.js.

## Como isso foi testado?

- Testes Manuais

## Informações adicionais

- https://mui.com/material-ui/react-link/
- https://nextjs.org/docs/pages/api-reference/components/link