### PR TITLE
Migra importação do Link no Footer para o componente compartilhado

### DIFF
--- a/src/app/(portal)/_components/footer/Footer.component.tsx
+++ b/src/app/(portal)/_components/footer/Footer.component.tsx
@@ -1,4 +1,5 @@
-import { IconButton, Link, Stack, Typography } from "@mui/material";
+import Link from "@/shared/lib/mui/components/link";
+import { IconButton, Stack, Typography } from "@mui/material";
 
 import LinkedInIcon from "@mui/icons-material/LinkedIn";
 import EmailIcon from "@mui/icons-material/Email";

--- a/src/shared/lib/mui/components/link/Link.component.tsx
+++ b/src/shared/lib/mui/components/link/Link.component.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import NextLink from "next/link";
 
 import { Link as MuiLink } from "@mui/material";


### PR DESCRIPTION
# Descrição

Este PR corrige o uso inconsistente do componente `Link` no `Footer`. O componente importava `Link` diretamente de `@mui/material`, desconsiderando o componente `Link` compartilhado e customizado do projeto.

A importação foi migrada para `@/shared/lib/mui/components/link`. Adicionalmente, a diretiva `"use client"` foi incluída no componente compartilhado `Link` para garantir a compatibilidade com o App Router do Next.js.

## Como isso foi testado?

- Testes Manuais
