### PR TITLE
Corrige recarregamento completo da página ao clicar em Tela Inicial no rodapé

### DIFF
--- a/src/app/(portal)/_components/footer/Footer.config.tsx
+++ b/src/app/(portal)/_components/footer/Footer.config.tsx
@@ -15,6 +15,6 @@ export const items = [
   },
   {
     label: "Tela Inicial",
-    href: "/",
+    href: "/#",
   },
 ];


### PR DESCRIPTION
# Descrição

Este PR altera o comportamento do link "Tela Inicial" no rodapé, que causava o recarregamento completo da página ao ser clicado. O problema ocorria porque o `href` estava definido como `"/"`, o que forçava uma nova requisição ao servidor em vez de uma navegação via hash, padrão adotado pelos demais links do rodapé.

A solução aplicada foi alterar o valor do `href` de `"/"` para `"/#"` no arquivo de configuração do Footer (`Footer.config.tsx`), eliminando o recarregamento completo e alinhando o comportamento ao padrão esperado.

## Como isso foi testado?

- Testes Manuais

