### PR TITLE
Adiciona menu mobile responsivo ao cabeçalho do portal

### DIFF
--- a/src/app/(portal)/_components/menu/Menu.component.tsx
+++ b/src/app/(portal)/_components/menu/Menu.component.tsx
@@ -3,22 +3,27 @@
 import Image from "next/image";
 
 import { AppBar, Container, Stack, Typography } from "@mui/material";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 import NavbarMenu from "./navbar-menu/NavbarMenu.component";
+import MenuMobile from "./menu-mobile/MenuMobile.component";
 
 function MenuComponent() {
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down("md"));
+  const logoSize = isMobile ? 40 : 54;
+
   return (
     <AppBar color="transparent" elevation={0} position="static">
       <Stack
         width="100%"
         alignItems="center"
         justifyContent="center"
-        paddingX={12}
+        paddingX={{ xs: 4, sm: 6, md: 12 }}
       >
         <Container
           maxWidth="xl"
           sx={{
-            paddingX: 0,
+            paddingX: { xs: 0 },
           }}
         >
           <Stack
@@ -27,9 +32,13 @@ function MenuComponent() {
             justifyContent="space-between"
             alignItems="center"
             width="100%"
-            paddingY={14}
+            paddingY={{ xs: 6, sm: 14 }}
           >
-            <Stack direction="row" spacing={6} alignItems="center">
+            <Stack
+              direction="row"
+              spacing={{ xs: 2, sm: 6 }}
+              alignItems="center"
+            >
               <Stack
                 bgcolor="background.paper"
                 borderRadius="50%"
@@ -40,13 +49,13 @@ function MenuComponent() {
                 <Image
                   src="/images/logo.svg"
                   alt="Logotipo"
-                  width={54}
-                  height={54}
+                  width={logoSize}
+                  height={logoSize}
                 />
               </Stack>
 
               <Typography
-                variant="h5"
+                variant={isMobile ? "h6" : "h5"}
                 color="text.primary"
                 fontFamily="var(--font-cookie)"
                 lineHeight={1}
@@ -56,7 +65,7 @@ function MenuComponent() {
               </Typography>
             </Stack>
 
-            <NavbarMenu />
+            {isMobile ? <MenuMobile /> : <NavbarMenu />}
           </Stack>
         </Container>
       </Stack>

--- a/src/app/(portal)/_components/menu/Menu.config.tsx
+++ b/src/app/(portal)/_components/menu/Menu.config.tsx
@@ -6,7 +6,7 @@ import {
   LINKEDIN_PROFILE_URL,
 } from "@/shared/constants/links.constants";
 
-import type { MenuItem } from "./NavbarMenu.types";
+import type { MenuItem } from "./navbar-menu/NavbarMenu.types";
 
 export const menuItems: MenuItem[] = [
   { label: "Projetos", href: "/#projects" },

--- a/src/app/(portal)/_components/menu/menu-mobile/MenuMobile.component.tsx
+++ b/src/app/(portal)/_components/menu/menu-mobile/MenuMobile.component.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+
+import MenuRoundedIcon from "@mui/icons-material/MenuRounded";
+import { IconButton } from "@mui/material";
+
+import MenuDrawer from "./menu-drawer/MenuDrawer.component";
+
+function MenuMobile() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  return (
+    <>
+      <IconButton color="info" onClick={() => setDrawerOpen(true)}>
+        <MenuRoundedIcon fontSize="large" />
+      </IconButton>
+
+      <MenuDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+    </>
+  );
+}
+
+export default MenuMobile;

--- a/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/MenuDrawer.component.tsx
+++ b/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/MenuDrawer.component.tsx
@@ -1,0 +1,67 @@
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import { Drawer, IconButton, Stack } from "@mui/material";
+
+import MenuItemWithDropdown from "./menu-item-with-dropdown/MenuItemWithDropdown.component";
+
+import { menuItems } from "../../Menu.config";
+import { StyledLink } from "./MenuDrawer.styles";
+import type { MenuDrawerProps } from "./MenuDrawer.types";
+
+function MenuDrawer({ open, onClose }: MenuDrawerProps) {
+  return (
+    <Drawer
+      anchor="top"
+      open={open}
+      onClose={onClose}
+      slotProps={{
+        paper: {
+          sx: {
+            bgcolor: "background.default",
+            borderBottom: 1,
+            borderColor: "divider",
+          },
+        },
+      }}
+    >
+      <Stack padding={4} position="relative">
+        <Stack padding={4} position="absolute" top={0} right={0}>
+          <IconButton color="info" onClick={onClose}>
+            <CloseRoundedIcon />
+          </IconButton>
+        </Stack>
+
+        <Stack component="nav" paddingY={6} spacing={1}>
+          {menuItems.map((item) => {
+            const hasDropdown = Array.isArray(item.dropdownItems);
+
+            return (
+              <Stack
+                key={item.label}
+                alignItems="center"
+                justifyContent="center"
+                width="100%"
+                spacing={2}
+              >
+                {hasDropdown ? (
+                  <MenuItemWithDropdown
+                    item={{
+                      label: item.label,
+                      dropdownItems: item.dropdownItems!,
+                    }}
+                    onClose={onClose}
+                  />
+                ) : (
+                  <StyledLink href={item.href} color="text" onClick={onClose}>
+                    {item.label}
+                  </StyledLink>
+                )}
+              </Stack>
+            );
+          })}
+        </Stack>
+      </Stack>
+    </Drawer>
+  );
+}
+
+export default MenuDrawer;

--- a/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/MenuDrawer.styles.ts
+++ b/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/MenuDrawer.styles.ts
@@ -1,0 +1,16 @@
+import Link from "@/shared/lib/mui/components/link";
+import { alpha, styled } from "@mui/material/styles";
+
+export const StyledLink = styled(Link)(({ theme }) => ({
+  textAlign: "center",
+  width: "100%",
+  color: theme.palette.text.primary,
+  padding: theme.spacing(2, 5),
+  borderRadius: theme.shape.borderRadius,
+  transition: theme.transitions.create("background-color", {
+    duration: theme.transitions.duration.short,
+  }),
+  "&:hover": {
+    backgroundColor: alpha(theme.palette.primary.main, 0.1),
+  },
+}));

--- a/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/MenuDrawer.types.ts
+++ b/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/MenuDrawer.types.ts
@@ -1,0 +1,4 @@
+export interface MenuDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}

--- a/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/menu-item-with-dropdown/MenuItemWithDropdown.component.tsx
+++ b/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/menu-item-with-dropdown/MenuItemWithDropdown.component.tsx
@@ -1,0 +1,63 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Link from "@/shared/lib/mui/components/link";
+
+import { MenuItemWithDropdownProps } from "./MenuItemWithDropdown.types";
+
+function MenuItemWithDropdown({ item, onClose }: MenuItemWithDropdownProps) {
+  return (
+    <Accordion
+      disableGutters
+      elevation={0}
+      sx={{
+        width: "100%",
+        bgcolor: "transparent",
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon color="info" />}
+        sx={{
+          paddingX: 5,
+          paddingY: 2,
+          minHeight: "auto",
+          "& .MuiAccordionSummary-content": {
+            margin: 0,
+            flexGrow: 0,
+          },
+        }}
+      >
+        <Typography color="info.main">{item.label}</Typography>
+      </AccordionSummary>
+
+      <AccordionDetails
+        sx={{
+          padding: 0,
+          bgcolor: "background.paper",
+          borderRadius: 1,
+        }}
+      >
+        <Stack paddingY={2}>
+          {item.dropdownItems.map((subItem) => (
+            <Link
+              key={subItem.label}
+              href={subItem.href}
+              color="info"
+              onClick={onClose}
+              sx={{ paddingX: 5, paddingY: 2 }}
+            >
+              {subItem.label}
+            </Link>
+          ))}
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+export default MenuItemWithDropdown;

--- a/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/menu-item-with-dropdown/MenuItemWithDropdown.types.ts
+++ b/src/app/(portal)/_components/menu/menu-mobile/menu-drawer/menu-item-with-dropdown/MenuItemWithDropdown.types.ts
@@ -1,0 +1,10 @@
+export interface MenuItemWithDropdownProps {
+  item: {
+    label: string;
+    dropdownItems: {
+      label: string;
+      href: string;
+    }[];
+  };
+  onClose: () => void;
+}

--- a/src/app/(portal)/_components/menu/navbar-menu/NavbarMenu.component.tsx
+++ b/src/app/(portal)/_components/menu/navbar-menu/NavbarMenu.component.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Button, Stack } from "@mui/material";
 
 import Dropdown from "./dropdown/Dropdown.component";
-import { menuItems } from "./NavbarMenu.config";
+import { menuItems } from "../Menu.config";
 
 function NavbarMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -33,7 +33,7 @@ function Loading() {
           },
         }}
       >
-        <Typography variant="body2" color="inherit">
+        <Typography variant="body1" color="inherit">
           Carregando
         </Typography>
 


### PR DESCRIPTION
# Descrição

Este PR adiciona um menu mobile responsivo ao cabeçalho do portal.

**Problema:** O componente `NavbarMenu` existente foi projetado exclusivamente para desktop, sem adaptação para telas menores, resultando em má experiência de uso em dispositivos móveis.

**Solução:** Foi criado o componente `MenuMobile`, que em breakpoints abaixo de `md` substitui o `NavbarMenu` por um botão de ícone que abre um `Drawer` ancorado no topo da tela (`MenuDrawer`). O drawer exibe os itens de navegação verticalmente, com suporte a itens com dropdown via `Accordion` (`MenuItemWithDropdown`). O arquivo de configuração `NavbarMenu.config.tsx` foi movido e renomeado para `Menu.config.tsx` para ser compartilhado entre os dois menus. O `Menu.component.tsx` foi ajustado com espaçamentos, tamanho de logo e variante tipográfica responsivos via breakpoints do MUI.

## Capturas/Gravação de tela




https://github.com/user-attachments/assets/9400a058-d577-4182-a73e-3902847fe069


<!-- Utilize este espaço para colocar quaisquer
informações que achar relevante.  --> 
## Como isso foi testado?

- Testes Manuais

