### PR TITLE
Adiciona regras customizadas ao ESLint para padronização do código

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,52 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      camelcase: [
+        "error",
+        {
+          ignoreImports: true,
+        },
+      ],
+      "react/jsx-filename-extension": ["error", { extensions: [".tsx"] }],
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        {
+          prefer: "type-imports",
+        },
+      ],
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: ["../*"],
+        },
+      ],
+      "react/function-component-definition": [
+        "error",
+        {
+          namedComponents: "function-declaration",
+          unnamedComponents: "arrow-function",
+        },
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ExportDefaultDeclaration > FunctionDeclaration",
+          message:
+            "Do not export functions directly in the default. Separate the declaration.",
+        },
+      ],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "all",
+          argsIgnorePattern: "^_",
+        },
+      ],
+      "func-style": ["error", "declaration", { allowArrowFunctions: true }],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:


### PR DESCRIPTION
# Descrição

Este PR adiciona um conjunto de regras customizadas ao ESLint, que anteriormente não possuía nenhuma regra própria definida além das herdadas das configurações do Next.js. A ausência dessas regras deixava a padronização estrutural e de estilo do código sem enforcement automático.

A solução foi adicionar um bloco de `rules` no arquivo `eslint.config.mjs` com as seguintes regras:

- `camelcase`: exige nomenclatura em camelCase;
- `react/jsx-filename-extension`: restringe o uso de JSX apenas a arquivos `.tsx`;
- `@typescript-eslint/consistent-type-imports`: exige o uso de `import type` para importações de tipos;
- `no-restricted-imports`: proíbe importações relativas com `../`;
- `react/function-component-definition`: exige que componentes nomeados sejam function declarations e componentes anônimos sejam arrow functions;
- `no-restricted-syntax`: proíbe exportar funções diretamente como `export default function`, exigindo que a declaração seja separada;
- `@typescript-eslint/no-unused-vars`: gera erro para variáveis não utilizadas, ignorando argumentos prefixados com `_`;
- `func-style`: exige o uso de function declarations, permitindo arrow functions;


## Como isso foi testado?

- Testes Manuais

