### PR TITLE
Corrige erros de lint convertendo imports relativos para absolutos e adicionando type-only imports

### DIFF
--- a/src/app/(portal)/_components/header/mobile-menu/menu-drawer/MenuDrawer.component.tsx
+++ b/src/app/(portal)/_components/header/mobile-menu/menu-drawer/MenuDrawer.component.tsx
@@ -3,7 +3,7 @@ import { Drawer, IconButton, Stack } from "@mui/material";
 
 import MenuItemWithDropdown from "./menu-item-with-dropdown/MenuItemWithDropdown.component";
 
-import { menuItems } from "../../Header.config";
+import { menuItems } from "@/app/(portal)/_components/header/Header.config";
 import { StyledLink } from "./MenuDrawer.styles";
 import type { MenuDrawerProps } from "./MenuDrawer.types";
 

--- a/src/app/(portal)/_components/header/mobile-menu/menu-drawer/menu-item-with-dropdown/MenuItemWithDropdown.component.tsx
+++ b/src/app/(portal)/_components/header/mobile-menu/menu-drawer/menu-item-with-dropdown/MenuItemWithDropdown.component.tsx
@@ -8,7 +8,7 @@ import {
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Link from "@/shared/lib/mui/components/link";
 
-import { MenuItemWithDropdownProps } from "./MenuItemWithDropdown.types";
+import type { MenuItemWithDropdownProps } from "./MenuItemWithDropdown.types";
 
 function MenuItemWithDropdown({ item, onClose }: MenuItemWithDropdownProps) {
   return (

--- a/src/app/(portal)/_components/header/navbar-menu/dropdown/Dropdown.types.ts
+++ b/src/app/(portal)/_components/header/navbar-menu/dropdown/Dropdown.types.ts
@@ -1,4 +1,4 @@
-import type { DropdownItem } from "../../Header.types";
+import type { DropdownItem } from "@/app/(portal)/_components/header/Header.types";
 
 export interface DropdownProps {
   anchorEl: null | HTMLElement;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,16 +22,21 @@ export const metadata: Metadata = {
     "Portfólio de Davhy Andrade, desenvolvedor web especializado em aplicações modernas com React e Next.js. Projetos autorais, design digital e fotografia.",
 };
 
-export default function RootLayout({
+function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
     <html lang="en">
-      <body className={`${openSans.className} ${cookie.variable}`} suppressHydrationWarning>
+      <body
+        className={`${openSans.className} ${cookie.variable}`}
+        suppressHydrationWarning
+      >
         <Providers>{children}</Providers>
       </body>
     </html>
   );
 }
+
+export default RootLayout;


### PR DESCRIPTION
# Descrição

Este PR corrige erros de lint identificados em componentes do header e no layout raiz da aplicação.

O problema estava na utilização de imports relativos frágeis (ex: `../../Header.config`) e na ausência do modificador `type` em imports exclusivamente tipados, ambos sinalizados pelo linter do projeto.

A solução aplicada foi converter os imports relativos para imports absolutos utilizando o alias `@/`, garantindo maior resiliência a refatorações de estrutura de pastas. Além disso, foi adicionado o modificador `type` nos imports de tipo puro (`import type`), corrigindo a respectiva regra de lint. No `layout.tsx`, a declaração `export default` foi separada da função `RootLayout` para conformidade com as regras de lint vigentes.


## Como isso foi testado?

- Testes Manuais


