### PR TITLE
Adiciona EditorConfig e remove configuração redundante do Prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,5 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "endOfLine": "lf",
   "arrowParens": "avoid"
 }


### PR DESCRIPTION
# Descrição

Este PR adiciona um arquivo `.editorconfig` ao projeto e remove uma configuração redundante do `.prettierrc`.

Anteriormente, o projeto não contava com um `.editorconfig`, o que pode causar inconsistências de formatação entre diferentes editores e ambientes de desenvolvimento. Além disso, o `.prettierrc` definia `endOfLine: "lf"` de forma redundante, já que essa responsabilidade passa a ser do `.editorconfig`.

A solução introduz o arquivo `.editorconfig` com as seguintes regras: charset UTF-8, quebra de linha LF, indentação com espaços de 2 unidades, inserção de nova linha ao final dos arquivos e remoção de espaços em branco no final das linhas. A configuração `endOfLine` foi removida do `.prettierrc`, pois agora é controlada pelo `.editorconfig`.


## Como isso foi testado?

- Testes Manuais

