### PR TITLE
Extrai configuração geral do ESLint para constante nomeada

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,53 @@ import nextTs from 'eslint-config-next/typescript';
 import prettier from 'eslint-config-prettier';
 import prettierPlugin from 'eslint-plugin-prettier';
 
+const generalConfig = {
+  rules: {
+    camelcase: [
+      'error',
+      {
+        ignoreImports: true,
+      },
+    ],
+    'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+      },
+    ],
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: ['../*'],
+      },
+    ],
+    'react/function-component-definition': [
+      'error',
+      {
+        namedComponents: 'function-declaration',
+        unnamedComponents: 'arrow-function',
+      },
+    ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ExportDefaultDeclaration > FunctionDeclaration',
+        message:
+          'Do not export functions directly in the default. Separate the declaration.',
+      },
+    ],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        args: 'all',
+        argsIgnorePattern: '^_',
+      },
+    ],
+    'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
+  },
+};
+
 const prettierConfig = {
   ...prettier,
   plugins: {
@@ -18,52 +65,7 @@ const prettierConfig = {
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  {
-    rules: {
-      camelcase: [
-        'error',
-        {
-          ignoreImports: true,
-        },
-      ],
-      'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
-      '@typescript-eslint/consistent-type-imports': [
-        'error',
-        {
-          prefer: 'type-imports',
-        },
-      ],
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: ['../*'],
-        },
-      ],
-      'react/function-component-definition': [
-        'error',
-        {
-          namedComponents: 'function-declaration',
-          unnamedComponents: 'arrow-function',
-        },
-      ],
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'ExportDefaultDeclaration > FunctionDeclaration',
-          message:
-            'Do not export functions directly in the default. Separate the declaration.',
-        },
-      ],
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          args: 'all',
-          argsIgnorePattern: '^_',
-        },
-      ],
-      'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
-    },
-  },
+  generalConfig,
   prettierConfig,
   // Override default ignores of eslint-config-next.
   globalIgnores([


### PR DESCRIPTION
# Descrição

Este PR refatora o arquivo `eslint.config.mjs` extraindo as regras ESLint que estavam definidas de forma anônima e inline dentro do array `eslintConfig` para uma constante nomeada `generalConfig`. A solução melhora a legibilidade e a organização do arquivo de configuração, tornando cada bloco de regras identificável pelo seu nome.


## Como isso foi testado?

- Testes Manuais

