### PR TITLE
Adiciona testes unitários ao componente Footer

### DIFF
--- a/src/app/(portal)/_components/footer/Footer.component.tsx
+++ b/src/app/(portal)/_components/footer/Footer.component.tsx
@@ -1,5 +1,4 @@
 import { IconButton, Link, Stack, Typography } from '@mui/material';
-
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import EmailIcon from '@mui/icons-material/Email';
 import GitHubIcon from '@mui/icons-material/GitHub';
@@ -38,20 +37,28 @@ function Footer() {
         </Stack>
 
         <Typography variant="caption" color="text.secondary" textAlign="center">
-          Meu Portfólio &copy; {new Date().getFullYear()} - 2022. Todos os
+          Meu Portfólio &copy; 2022 - {new Date().getFullYear()}. Todos os
           direitos reservados.
         </Typography>
 
         <Stack direction="row" spacing={2} justifyContent="center">
-          <IconButton href={LINKEDIN_PROFILE_URL} color="info">
+          <IconButton
+            href={LINKEDIN_PROFILE_URL}
+            color="info"
+            data-testid="linkedin-button"
+          >
             <LinkedInIcon fontSize="small" />
           </IconButton>
 
-          <IconButton href={GITHUB_PROFILE_URL} color="info">
+          <IconButton
+            href={GITHUB_PROFILE_URL}
+            color="info"
+            data-testid="github-button"
+          >
             <GitHubIcon fontSize="small" />
           </IconButton>
 
-          <IconButton href={EMAIL_URL} color="info">
+          <IconButton href={EMAIL_URL} color="info" data-testid="email-button">
             <EmailIcon fontSize="small" />
           </IconButton>
         </Stack>

--- a/src/app/(portal)/_components/footer/__tests__/Footer.component.test.tsx
+++ b/src/app/(portal)/_components/footer/__tests__/Footer.component.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+
+import {
+  EMAIL_URL,
+  GITHUB_PROFILE_URL,
+  LINKEDIN_PROFILE_URL,
+} from '@/shared/constants/links.constants';
+
+import Footer from '../Footer.component';
+
+jest.useFakeTimers().setSystemTime(new Date('2026-04-01'));
+
+it('renders the footer correctly', () => {
+  render(<Footer />);
+
+  expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+});
+
+it('renders the contact link correctly', () => {
+  render(<Footer />);
+
+  expect(screen.getByRole('link', { name: 'Contato' })).toBeInTheDocument();
+});
+
+it('renders the about link correctly', () => {
+  render(<Footer />);
+
+  expect(screen.getByRole('link', { name: 'Sobre' })).toBeInTheDocument();
+});
+
+it('renders the projects link correctly', () => {
+  render(<Footer />);
+
+  expect(screen.getByRole('link', { name: 'Projetos' })).toBeInTheDocument();
+});
+
+it('renders the initial screen link correctly', () => {
+  render(<Footer />);
+
+  expect(
+    screen.getByRole('link', { name: 'Tela Inicial' }),
+  ).toBeInTheDocument();
+});
+
+it('renders the github button correctly', () => {
+  render(<Footer />);
+
+  expect(screen.getByTestId('github-button')).toHaveAttribute(
+    'href',
+    GITHUB_PROFILE_URL,
+  );
+});
+
+it('renders the linkedin button correctly', () => {
+  render(<Footer />);
+
+  expect(screen.getByTestId('linkedin-button')).toHaveAttribute(
+    'href',
+    LINKEDIN_PROFILE_URL,
+  );
+});
+
+it('renders the email button correctly', () => {
+  render(<Footer />);
+
+  expect(screen.getByTestId('email-button')).toHaveAttribute('href', EMAIL_URL);
+});
+
+it('renders the correct copyright year', () => {
+  render(<Footer />);
+
+  expect(
+    screen.getByText(
+      'Meu Portfólio © 2022 - 2026. Todos os direitos reservados.',
+    ),
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
# Descrição

Este PR adiciona testes unitários ao componente `Footer`, que até então não possuía cobertura de testes. Para viabilizar a testabilidade dos botões de redes sociais, foram adicionados atributos `data-testid` nos `IconButton` de LinkedIn, GitHub e E-mail. Adicionalmente, a ordem dos anos no texto de copyright foi corrigida de `{ano} - 2022` para `2022 - {ano}`.

Os testes cobrem a renderização do footer, os links de navegação (Tela Inicial, Projetos, Sobre e Contato), os botões de redes sociais com suas respectivas URLs e a exibição correta do ano no copyright.




## Como isso foi testado?

- Testes Unitários
