### PR TITLE
Adiciona plugin eslint-plugin-import com regra de ordenação de imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import prettier from 'eslint-config-prettier';
 import prettierPlugin from 'eslint-plugin-prettier';
 import jestPlugin from 'eslint-plugin-jest';
 import testingLibraryPlugin from 'eslint-plugin-testing-library';
+import importPlugin from 'eslint-plugin-import';
 
 const generalConfig = {
   rules: {
@@ -87,16 +88,43 @@ const jestConfig = [
       'jest/prefer-lowercase-title': 'error',
       'testing-library/prefer-user-event-setup': 'error',
       'testing-library/prefer-user-event': 'error',
+      'no-restricted-imports': 'off',
     },
   },
 ];
 
+const importConfig = {
+  ...importPlugin.flatConfigs.recommended,
+  files: ['**/*.ts', '**/*.tsx'],
+  plugins: {
+    import: importPlugin,
+  },
+  rules: {
+    ...importPlugin.flatConfigs.recommended.rules,
+    'import/order': [
+      'error',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+        ],
+        'newlines-between': 'always',
+      },
+    ],
+  },
+};
+
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  ...jestConfig,
   generalConfig,
+  ...jestConfig,
   prettierConfig,
+  importConfig,
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.15.1",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-testing-library": "^7.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,7 +2527,7 @@ eslint-module-utils@^2.12.1:
 
 eslint-plugin-import@^2.32.0:
   version "2.32.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz#602b55faa6e4caeaa5e970c198b5c00a37708980"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
   dependencies:
     "@rtsao/scc" "^1.1.0"


### PR DESCRIPTION
# Descrição

Este PR adiciona o plugin `eslint-plugin-import` à configuração do ESLint e define a regra `import/order` para impor uma ordem padronizada nas importações do projeto.

Sem essa configuração, não havia nenhuma regra que garantisse a organização dos imports, o que tornava o código inconsistente entre arquivos. A solução aplicada cria um bloco `importConfig` com os grupos de ordenação definidos (builtin, external, internal, parent, sibling, index), exige linha em branco entre os grupos via `newlines-between: 'always'`. A regra `no-restricted-imports` também foi desativada no escopo de testes para evitar conflito. O plugin é aplicado apenas em arquivos `.ts` e `.tsx`.

## Como isso foi testado?

- Testes Manuais

