### PR TITLE
Adiciona arquivo .gitattributes para padronizar terminações de linha

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eof=lf


### PR DESCRIPTION
# Descrição

Este PR adiciona o arquivo `.gitattributes` ao repositório para padronizar as terminações de linha em todos os arquivos do projeto.

Sem essa configuração, diferentes sistemas operacionais (Windows, Linux, macOS) podem gravar arquivos com terminações de linha distintas (CRLF ou LF), causando inconsistências no histórico do Git e potenciais conflitos entre colaboradores. A regra `* text=auto eof=lf` instrui o Git a normalizar automaticamente as terminações de linha e forçar o uso de LF em todos os arquivos versionados.

## Como isso foi testado?

- Testes Manuais
