### PR TITLE
Aplica correções automáticas do ESLint nos arquivos do projeto

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'jest';
+
 import nextJest from 'next/jest.js';
 
 /**

--- a/src/app/(portal)/_components/footer/Footer.component.tsx
+++ b/src/app/(portal)/_components/footer/Footer.component.tsx
@@ -1,7 +1,7 @@
-import { IconButton, Link, Stack, Typography } from '@mui/material';
-import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import EmailIcon from '@mui/icons-material/Email';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import { IconButton, Link, Stack, Typography } from '@mui/material';
 
 import {
   EMAIL_URL,

--- a/src/app/(portal)/_components/header/Header.component.tsx
+++ b/src/app/(portal)/_components/header/Header.component.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Image from 'next/image';
 import { AppBar, Container, Stack, Typography } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import Image from 'next/image';
 
 import MenuMobile from './mobile-menu/MobileMenu.component';
 import NavbarMenu from './navbar-menu/NavbarMenu.component';

--- a/src/app/(portal)/_components/header/Header.config.tsx
+++ b/src/app/(portal)/_components/header/Header.config.tsx
@@ -1,12 +1,12 @@
-import { Divider, Stack } from '@mui/material';
+import type { MenuItem } from './Header.types';
+
 import PhoneInTalkRoundedIcon from '@mui/icons-material/PhoneInTalkRounded';
+import { Divider, Stack } from '@mui/material';
 
 import {
   GALLERY_URL,
   LINKEDIN_PROFILE_URL,
 } from '@/shared/constants/links.constants';
-
-import type { MenuItem } from './Header.types';
 
 export const menuItems: MenuItem[] = [
   { label: 'Projetos', href: '/#projects' },

--- a/src/app/(portal)/_components/header/mobile-menu/MobileMenu.component.tsx
+++ b/src/app/(portal)/_components/header/mobile-menu/MobileMenu.component.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import { IconButton } from '@mui/material';
+import { useState } from 'react';
 
 import MenuDrawer from './menu-drawer/MenuDrawer.component';
 

--- a/src/app/(portal)/_components/header/mobile-menu/menu-drawer/MenuDrawer.component.tsx
+++ b/src/app/(portal)/_components/header/mobile-menu/menu-drawer/MenuDrawer.component.tsx
@@ -1,3 +1,5 @@
+import type { MenuDrawerProps } from './MenuDrawer.types';
+
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import { Drawer, IconButton, Stack } from '@mui/material';
 
@@ -5,7 +7,6 @@ import { menuItems } from '@/app/(portal)/_components/header/Header.config';
 
 import MenuItemWithDropdown from './menu-item-with-dropdown/MenuItemWithDropdown.component';
 import { StyledLink } from './MenuDrawer.styles';
-import type { MenuDrawerProps } from './MenuDrawer.types';
 
 function MenuDrawer({ open, onClose }: MenuDrawerProps) {
   return (

--- a/src/app/(portal)/_components/header/mobile-menu/menu-drawer/menu-item-with-dropdown/MenuItemWithDropdown.component.tsx
+++ b/src/app/(portal)/_components/header/mobile-menu/menu-drawer/menu-item-with-dropdown/MenuItemWithDropdown.component.tsx
@@ -1,3 +1,6 @@
+import type { MenuItemWithDropdownProps } from './MenuItemWithDropdown.types';
+
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
   Accordion,
   AccordionDetails,
@@ -5,11 +8,8 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 import Link from '@/shared/lib/mui/components/link';
-
-import type { MenuItemWithDropdownProps } from './MenuItemWithDropdown.types';
 
 function MenuItemWithDropdown({ item, onClose }: MenuItemWithDropdownProps) {
   return (

--- a/src/app/(portal)/_components/header/navbar-menu/NavbarMenu.component.tsx
+++ b/src/app/(portal)/_components/header/navbar-menu/NavbarMenu.component.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { Button, Stack } from '@mui/material';
+import { useState } from 'react';
 
 import { menuItems } from '@/app/(portal)/_components/header/Header.config';
 

--- a/src/app/(portal)/_components/header/navbar-menu/dropdown/Dropdown.component.tsx
+++ b/src/app/(portal)/_components/header/navbar-menu/dropdown/Dropdown.component.tsx
@@ -1,7 +1,7 @@
-import Link from 'next/link';
-import { Menu, MenuItem } from '@mui/material';
-
 import type { DropdownProps } from './Dropdown.types';
+
+import { Menu, MenuItem } from '@mui/material';
+import Link from 'next/link';
 
 function Dropdown({ anchorEl, isOpen, onClose, items }: DropdownProps) {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+
 import { Cookie, Open_Sans } from 'next/font/google';
 
 import './globals.css';

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
+
 import { ThemeProvider } from '@mui/material/styles';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 

--- a/src/shared/lib/mui/components/link/Link.component.tsx
+++ b/src/shared/lib/mui/components/link/Link.component.tsx
@@ -1,6 +1,7 @@
-import NextLink from 'next/link';
-import { Link as MuiLink } from '@mui/material';
 import type { LinkProps } from '@mui/material';
+
+import { Link as MuiLink } from '@mui/material';
+import NextLink from 'next/link';
 
 function Link({ href, children, ...rest }: LinkProps) {
   return (

--- a/src/shared/lib/mui/theme/theme.config.ts
+++ b/src/shared/lib/mui/theme/theme.config.ts
@@ -1,11 +1,11 @@
 import { createTheme } from '@mui/material/styles';
 
 import breakpoints from './breakpoints/breakpoints.config';
-import typography from './typography/typography.config';
-import palette from './palette/palette.config';
+import { MuiButton } from './components/button/button.config';
 import { MuiLink } from './components/link/link.config';
 import { MuiTypography } from './components/typography/typography.config';
-import { MuiButton } from './components/button/button.config';
+import palette from './palette/palette.config';
+import typography from './typography/typography.config';
 
 const theme = createTheme({
   cssVariables: true,


### PR DESCRIPTION
# Descrição

Este PR corrige a ordenação das importações em 13 arquivos do projeto, que estavam fora da ordem exigida pelas regras do ESLint. O autofix reorganizou as importações de tipos (`import type`) para o topo de cada arquivo, reordenou as importações de terceiros e adicionou linhas em branco entre os grupos de importações conforme as regras configuradas.

## Como isso foi testado?

- Testes Manuais

